### PR TITLE
dealing with ulimit in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,7 @@ ldm:
     - ./logs/:/home/ldm/var/logs/
   ports:
     - "388:388"
+  ulimits:
+    nofile:
+      soft: 1024
+      hard: 1024


### PR DESCRIPTION
with the ulimit set, the ldm will have a limited number of file descriptors and disks will no longer fill up