### PR TITLE
6.13.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,32 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## 6.13.6 - 2017-02-06
+## [6.13.7] - 2019-02-08
+
+### Changed
+- crontab improvements, [a47c842](https://github.com/Unidata/ldm-docker/commit/a47c842)
+- `yum -y update yum`, [9557343](https://github.com/Unidata/ldm-docker/commit/9557343)
+- chown changes, [dc703b6](https://github.com/Unidata/ldm-docker/commit/dc703b6)
+- runtime improvements in how permissions are handled, [e8bf062](https://github.com/Unidata/ldm-docker/commit/e8bf062)
+- modernized `docker-compose.yml`, [0f2e2af](https://github.com/Unidata/ldm-docker/commit/0f2e2af)
+- information about support, [90347f4](https://github.com/Unidata/ldm-docker/commit/90347f4)
+- `.profile` to include `~/bin` in `PATH`, [0f50b1e](https://github.com/Unidata/ldm-docker/commit/0f50b1e)
+- update `gosu`, [79c94bd](https://github.com/Unidata/ldm-docker/commit/79c94bd)
+- added `libstdc++-static` for `6.13.7`, [79c94bd](https://github.com/Unidata/ldm-docker/commit/79c94bd)
+
+### Added
+- scouring utilities, [226c3a5](https://github.com/Unidata/ldm-docker/commit/226c3a5)
+- DOI citation, [9e0b79c](https://github.com/Unidata/ldm-docker/commit/9e0b79c)
+- parameterizable UID, GID, [27b8201](https://github.com/Unidata/ldm-docker/commit/27b8201)
+- working example, [0a1a731](https://github.com/Unidata/ldm-docker/commit/0a1a731)
+
+## [6.13.6] - 2017-02-06
 
 ### Changed
 
 - In Dockerfile libpng-dev -> libpng-devel for CentOS
 
-## 6.13.5 - 2016-11-01
+## [6.13.5] - 2016-11-01
 
 ### Added
 
@@ -22,7 +41,7 @@ All notable changes to this project will be documented in this file. This change
 - ulimit set in `docker-compose.yml`
 - cleaning up `tar.gz` file (does not need to end up in container).
 
-## 6.13.4 - 2016-08-17
+## [6.13.4] - 2016-08-17
 
 ### Added
 
@@ -37,13 +56,14 @@ All notable changes to this project will be documented in this file. This change
 - Miscellaneous `Dockerfile` clean up
 - Miscellaneous `.travis.yml` clean up
 
-## 6.13.3 - 2016-07-22
+## [6.13.3] - 2016-07-22
 
 ### Added
 - `README` additions
 - `docker-compose.yml` `ldm` container name reference
 
-[Unreleased]: https://github.com/Unidata/ldm-docker/compare/v6.13.6...HEAD
+[Unreleased]: https://github.com/Unidata/ldm-docker/compare/v6.13.7...HEAD
+[6.13.7]: https://github.com/Unidata/ldm-docker/compare/v6.13.6...v6.13.7
 [6.13.6]: https://github.com/Unidata/ldm-docker/compare/v6.13.5...v6.13.6
 [6.13.5]: https://github.com/Unidata/ldm-docker/compare/v6.13.4...v6.13.5
 [6.13.4]: https://github.com/Unidata/ldm-docker/compare/v6.13.3...v6.13.4


### PR DESCRIPTION
closes #67 and #66.

Earlier versions of the LDM annoyingly disappear so this has to be done in one shot.