### PR TITLE
Set umask in entrypoint to add group write permissions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# set umask:
+umask 0002
+
 if [ "$1" = 'runldm.sh' ]; then
 
     USER_ID=${LDM_USER_ID:-1000}
@@ -21,6 +24,9 @@ if [ "$1" = 'runldm.sh' ]; then
             chown ldm:ldm "$j"
         fi
     done
+
+    # add group rwx permissions to product queue dir
+    chmod -R 775 /var/queues
 
     # chown everything in ${HOME} except var/data which will take too long
     cd ${HOME} && chown -R ldm:ldm $(ls -A | awk '{if($1 != "var"){ print $1 }}')


### PR DESCRIPTION
I am running the LDM container using an installation of Docker with a user namespace setup. In short, the container 'root/0' and 'ldm/1000' users are mapped to UIDs 100000 and 101000 outside of the container.

This causes issues when a bind mount is setup allowing files to be written on the host. The files that the LDM container writes (including the product queue) have default permissions of 755 and have ownership of UID 101000. Standard user accounts on the host are unable to edit or remove the LDM related files written to the bind mount directory due to not having ownership or write permissions.

My solution is to change the umask (enabling group write perms by default using umask 0002) in the LDM container and to setup a group on the host machine with GID of 101000 and adding any Docker users on the host to the group. This should allow the editing or removal of LDM files without the use of sudo.

I hope this is clear about what I'm trying to do. This is only an issue when Docker is running with user namespace enabled (done for security purposes).

https://docs.docker.com/engine/security/userns-remap/